### PR TITLE
replace the broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ The core logic for posting and retrieving data is implemented in the zerogravity
 
 ### Learn More About 0G
 
-[0G Website](https://0g.org/)
-[0G Github](https://github.com/0g-project/0g)
+[0G Website](https://0g.ai/)
+[0G Github](https://github.com/0glabs)
 
 ### Learn More About Arbitrum Orbit
 
-[Arbitrum Orbit Docs](https://developer.arbitrum.io/orbit)
+[Arbitrum Orbit Docs](https://docs.arbitrum.io/launch-orbit-chain/orbit-gentle-introduction)


### PR DESCRIPTION
This pull request includes updates to the `README.md` file to correct outdated links. The most important changes include updating the URLs for the 0G project and the Arbitrum Orbit documentation.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R40): Updated the 0G project website URL from `https://0g.org/` to `https://0g.ai/` and the GitHub URL from `https://github.com/0g-project/0g` to `https://github.com/0glabs`.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L35-R40): Updated the Arbitrum Orbit documentation URL from `https://developer.arbitrum.io/orbit` to `https://docs.arbitrum.io/launch-orbit-chain/orbit-gentle-introduction`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/0glabs/nitro/6)
<!-- Reviewable:end -->
